### PR TITLE
Optimize ChecksumIEEE helper

### DIFF
--- a/crc32.go
+++ b/crc32.go
@@ -135,4 +135,4 @@ func Checksum(data []byte, tab *Table) uint32 { return Update(0, tab, data) }
 
 // ChecksumIEEE returns the CRC-32 checksum of data
 // using the IEEE polynomial.
-func ChecksumIEEE(data []byte) uint32 { return update(0, IEEETable, data) }
+func ChecksumIEEE(data []byte) uint32 { return updateIEEE(0, data) }


### PR DESCRIPTION
It was calling the fallback `update` method directly and so wasn't seeing any
optimization. Call `updateIEEE` instead which includes the optimized path (and
bypasses the unnecessary switch on the table vs just calling `Update`).

@klauspost 
cc @wvanbergen

This explains the confusion we ran into trying to benchmark https://github.com/Shopify/sarama/pull/527