### PR TITLE
Use slicing by 8 more aggressively.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Install using `go get github.com/klauspost/crc32`. This library is based on Go 1
 
 Replace `import "hash/crc32"` with `import "github.com/klauspost/crc32"` and you are good to go.
 
+# changes
+
+* Dec 4, 2015: Uses the "slice-by-8" trick more extensively, which gives a 1.5 to 2.5x speedup if assembler is unavailable.
+
+
 # performance
 
 For IEEE tables (the most common), there is approximately a factor 10 speedup with "CLMUL" (Carryless multiplication) instruction:
@@ -24,7 +29,55 @@ BenchmarkCrc32KB     327.83       3194.20      9.74x
 
 For other tables and "CLMUL"  capable machines the performance is the same as the standard library.
 
-This has been submitted and will be part of the Go 1.6 standard library.
+Here are som detailed becnhmarks, comparing to go 1.5 standard library with and without assembler enabled.
+
+```
+Std:   Standard Go 1.5 library
+Crc:   Indicates IEEE type CRC.
+40B:   Size of each slice encoded.
+NoAsm: Assembler was disabled (ie. not an AMD64 or SSE 4.2+ capable machine).
+Castagnoli: Castagnoli CRC type.
+
+BenchmarkStdCrc40B-4            10000000               158 ns/op         252.88 MB/s
+BenchmarkCrc40BNoAsm-4          20000000               105 ns/op         377.38 MB/s (slice8)
+BenchmarkCrc40B-4               20000000               105 ns/op         378.77 MB/s (slice8)
+
+BenchmarkStdCrc1KB-4              500000              3604 ns/op         284.10 MB/s
+BenchmarkCrc1KBNoAsm-4           1000000              1463 ns/op         699.79 MB/s (slice8)
+BenchmarkCrc1KB-4                3000000               396 ns/op        2583.69 MB/s (asm)
+
+BenchmarkStdCrc8KB-4              200000             11417 ns/op         717.48 MB/s (slice8)
+BenchmarkCrc8KBNoAsm-4            200000             11317 ns/op         723.85 MB/s (slice8)
+BenchmarkCrc8KB-4                 500000              2919 ns/op        2805.73 MB/s (asm)
+
+BenchmarkStdCrc32KB-4              30000             45749 ns/op         716.24 MB/s (slice8)
+BenchmarkCrc32KBNoAsm-4            30000             45109 ns/op         726.42 MB/s (slice8)
+BenchmarkCrc32KB-4                100000             11497 ns/op        2850.09 MB/s (asm)
+
+BenchmarkStdNoAsmCastagnol40B-4 10000000               161 ns/op         246.94 MB/s
+BenchmarkStdCastagnoli40B-4     50000000              28.4 ns/op        1410.69 MB/s (asm)
+BenchmarkCastagnoli40BNoAsm-4   20000000               100 ns/op         398.01 MB/s (slice8)
+BenchmarkCastagnoli40B-4        50000000              28.2 ns/op        1419.54 MB/s (asm)
+
+BenchmarkStdNoAsmCastagnoli1KB-4  500000              3622 ns/op        282.67 MB/s
+BenchmarkStdCastagnoli1KB-4     10000000               144 ns/op        7099.78 MB/s (asm)
+BenchmarkCastagnoli1KBNoAsm-4    1000000              1475 ns/op         694.14 MB/s (slice8)
+BenchmarkCastagnoli1KB-4        10000000               146 ns/op        6993.35 MB/s (asm)
+
+BenchmarkStdNoAsmCastagnoli8KB-4  50000              28781 ns/op         284.63 MB/s
+BenchmarkStdCastagnoli8KB-4      1000000              1029 ns/op        7957.89 MB/s (asm)
+BenchmarkCastagnoli8KBNoAsm-4     200000             11410 ns/op         717.94 MB/s (slice8)
+BenchmarkCastagnoli8KB-4         1000000              1000 ns/op        8188.71 MB/s (asm)
+
+BenchmarkStdNoAsmCastagnoli32KB-4  10000            115426 ns/op         283.89 MB/s
+BenchmarkStdCastagnoli32KB-4      300000              4065 ns/op        8059.13 MB/s (asm)
+BenchmarkCastagnoli32KBNoAsm-4     30000             45171 ns/op         725.41 MB/s (slice8)
+BenchmarkCastagnoli32KB-4         500000              4077 ns/op        8035.89 MB/s (asm)
+```
+
+The IEEE assembler optimizations has been submitted and will be part of the Go 1.6 standard library.
+
+However, the improved use of slice-by-8 has not, but will probably be submitted for Go 1.7.
 
 # license
 

--- a/crc32.go
+++ b/crc32.go
@@ -45,10 +45,12 @@ type Table [256]uint32
 // Castagnoli table so we can compare against it to find when the caller is
 // using this polynomial.
 var castagnoliTable *Table
+var castagnoliTable8 *slicing8Table
 var castagnoliOnce sync.Once
 
 func castagnoliInit() {
 	castagnoliTable = makeTable(Castagnoli)
+	castagnoliTable8 = makeTable8(Castagnoli)
 }
 
 // IEEETable is the table for the IEEE polynomial.
@@ -143,15 +145,17 @@ func updateSlicingBy8(crc uint32, tab *slicing8Table, p []byte) uint32 {
 		p = p[8:]
 	}
 	crc = ^crc
+	if len(p) == 0 {
+		return crc
+	}
 	return update(crc, &tab[0], p)
 }
 
 // Update returns the result of adding the bytes in p to the crc.
 func Update(crc uint32, tab *Table, p []byte) uint32 {
-	switch tab {
-	case castagnoliTable:
+	if tab == castagnoliTable {
 		return updateCastagnoli(crc, p)
-	case IEEETable:
+	} else if tab == IEEETable {
 		return updateIEEE(crc, p)
 	}
 	return update(crc, tab, p)

--- a/crc32_amd64.go
+++ b/crc32_amd64.go
@@ -15,10 +15,12 @@ func haveCLMUL() bool
 
 // castagnoliSSE42 is defined in crc_amd64.s and uses the SSE4.2 CRC32
 // instruction.
+// go:noescape
 func castagnoliSSE42(crc uint32, p []byte) uint32
 
 // ieeeCLMUL is defined in crc_amd64.s and uses the PCLMULQDQ
 // instruction as well as SSE 4.1.
+// go:noescape
 func ieeeCLMUL(crc uint32, p []byte) uint32
 
 var sse42 = haveSSE42()
@@ -27,6 +29,10 @@ var useFastIEEE = haveCLMUL() && haveSSE41()
 func updateCastagnoli(crc uint32, p []byte) uint32 {
 	if sse42 {
 		return castagnoliSSE42(crc, p)
+	}
+	// only use slicing-by-8 when input is >= 16 Bytes
+	if len(p) >= 16 {
+		return updateSlicingBy8(crc, castagnoliTable8, p)
 	}
 	return update(crc, castagnoliTable, p)
 }
@@ -42,8 +48,8 @@ func updateIEEE(crc uint32, p []byte) uint32 {
 		return crc
 	}
 
-	// only use slicing-by-8 when input is >= 4KB
-	if len(p) >= 4096 {
+	// only use slicing-by-8 when input is >= 16 Bytes
+	if len(p) >= 16 {
 		iEEETable8Once.Do(func() {
 			iEEETable8 = makeTable8(IEEE)
 		})

--- a/crc32_generic.go
+++ b/crc32_generic.go
@@ -6,16 +6,19 @@
 
 package crc32
 
-// The file contains the generic version of updateCastagnoli which just calls
-// the software implementation.
-
+// The file contains the generic version of updateCastagnoli which does
+// slicing-by-8, or uses the fallback for very small sizes.
 func updateCastagnoli(crc uint32, p []byte) uint32 {
+	// only use slicing-by-8 when input is >= 16 Bytes
+	if len(p) >= 16 {
+		return updateSlicingBy8(crc, castagnoliTable8, p)
+	}
 	return update(crc, castagnoliTable, p)
 }
 
 func updateIEEE(crc uint32, p []byte) uint32 {
-	// only use slicing-by-8 when input is >= 4KB
-	if len(p) >= 4096 {
+	// only use slicing-by-8 when input is >= 16 Bytes
+	if len(p) >= 16 {
 		iEEETable8Once.Do(func() {
 			iEEETable8 = makeTable8(IEEE)
 		})

--- a/crc32_test.go
+++ b/crc32_test.go
@@ -83,6 +83,14 @@ func TestGolden(t *testing.T) {
 	}
 }
 
+func BenchmarkCrc40B(b *testing.B) {
+	benchmark(b, NewIEEE(), 40)
+}
+
+func BenchmarkStdCrc40B(b *testing.B) {
+	benchmark(b, crc32.NewIEEE(), 40)
+}
+
 func BenchmarkCrc1KB(b *testing.B) {
 	benchmark(b, NewIEEE(), 1024)
 }
@@ -107,6 +115,38 @@ func BenchmarkStdCrc32KB(b *testing.B) {
 	benchmark(b, crc32.NewIEEE(), 32*1024)
 }
 
+func BenchmarkCastagnoli40B(b *testing.B) {
+	benchmark(b, New(MakeTable(Castagnoli)), 40)
+}
+
+func BenchmarkStdCastagnoli40B(b *testing.B) {
+	benchmark(b, crc32.New(crc32.MakeTable(Castagnoli)), 40)
+}
+
+func BenchmarkCastagnoli1KB(b *testing.B) {
+	benchmark(b, New(MakeTable(Castagnoli)), 1024)
+}
+
+func BenchmarkStdCastagnoli1KB(b *testing.B) {
+	benchmark(b, crc32.New(crc32.MakeTable(Castagnoli)), 1024)
+}
+
+func BenchmarkCastagnoli8KB(b *testing.B) {
+	benchmark(b, New(MakeTable(Castagnoli)), 8*1024)
+}
+
+func BenchmarkStdCastagnoli8KB(b *testing.B) {
+	benchmark(b, crc32.New(crc32.MakeTable(Castagnoli)), 8*1024)
+}
+
+func BenchmarkCastagnoli32KB(b *testing.B) {
+	benchmark(b, New(MakeTable(Castagnoli)), 32*1024)
+}
+
+func BenchmarkStdCastagnoli32KB(b *testing.B) {
+	benchmark(b, crc32.New(crc32.MakeTable(Castagnoli)), 32*1024)
+}
+
 func benchmark(b *testing.B, h hash.Hash32, n int64) {
 	b.SetBytes(n)
 	data := make([]byte, n)
@@ -114,6 +154,12 @@ func benchmark(b *testing.B, h hash.Hash32, n int64) {
 		data[i] = byte(i)
 	}
 	in := make([]byte, 0, h.Size())
+
+	// Warm up
+	h.Reset()
+	h.Write(data)
+	h.Sum(in)
+
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
Use slicing by 8 for smaller IEEE sizes, and use it for Castagnoli tables as well, if there is no SSE 4.2 available.

Slicing-by-8 seems to be faster from around 16-20 byte size slices and upwards. 40 bytes is approximately 1.5x the speed.

Non SSE 4.2 performance:
```
benchmark                     old ns/op     new ns/op     delta
BenchmarkCastagnoli40B-4      161           105           -34.78%
BenchmarkCastagnoli1KB-4      3603          1505          -58.23%
BenchmarkCastagnoli8KB-4      28741         12103         -57.89%
BenchmarkCastagnoli32KB-4     114681        47015         -59.00%

benchmark                     old MB/s     new MB/s     speedup
BenchmarkCastagnoli40B-4      247.50       378.79       1.53x
BenchmarkCastagnoli1KB-4      284.19       680.36       2.39x
BenchmarkCastagnoli8KB-4      285.02       676.82       2.37x
BenchmarkCastagnoli32KB-4     285.73       696.96       2.44x
```

IEEE 40 byte/update speed:
```
benchmark             old ns/op     new ns/op     delta
BenchmarkCrc40B-4     161           110           -31.68%

benchmark             old MB/s     new MB/s     speedup
BenchmarkCrc40B-4     247.95       361.54       1.46x
```