### PR TITLE
Add js to generic build.

### DIFF
--- a/crc32_amd64.go
+++ b/crc32_amd64.go
@@ -1,8 +1,8 @@
-//+build !appengine,!gccgo
-
 // Copyright 2011 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
+// +build !appengine,!gccgo
 
 package crc32
 

--- a/crc32_amd64.s
+++ b/crc32_amd64.s
@@ -1,8 +1,8 @@
-//+build gc
-
 // Copyright 2011 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
+// +build gc
 
 #define NOSPLIT 4
 #define RODATA 8

--- a/crc32_amd64p32.go
+++ b/crc32_amd64p32.go
@@ -1,8 +1,8 @@
-//+build !appengine,!gccgo
-
 // Copyright 2011 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
+// +build !appengine,!gccgo
 
 package crc32
 

--- a/crc32_amd64p32.s
+++ b/crc32_amd64p32.s
@@ -1,8 +1,8 @@
-//+build gc
-
 // Copyright 2011 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
+// +build gc
 
 #define NOSPLIT 4
 #define RODATA 8

--- a/crc32_generic.go
+++ b/crc32_generic.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build 386 arm arm64 ppc64 ppc64le appengine gccgo
+// +build !amd64,!amd64p32 appengine gccgo
 
 package crc32
 


### PR DESCRIPTION
Fixes gopherjs/gopherjs#378. /cc @kaustavha

I've tested, and its `TestGolden` passes using `gopherjs` compiler after this change:

```
crc32 $ go test -v
=== RUN   TestGolden
--- PASS: TestGolden (0.00s)
=== RUN   ExampleMakeTable
--- PASS: ExampleMakeTable (0.00s)
PASS
ok  	github.com/klauspost/crc32	0.005s

crc32 $ gopherjs test -v
crc32.go:157:10: undeclared name: updateCastagnoli
crc32.go:159:10: undeclared name: updateIEEE
crc32.go:182:48: undeclared name: updateIEEE

crc32 $ nano crc32_generic.go

crc32 $ gopherjs test -v
gopherjs: Source maps disabled. Use Node.js 4.x with source-map-support module for nice stack traces.
=== RUN   TestGolden
--- PASS: TestGolden (0.01s)
PASS
warning: system calls not available, see https://github.com/gopherjs/gopherjs/blob/master/doc/syscalls.md
ok  	github.com/klauspost/crc32	0.276s
```