### PR TITLE
crc32: align more with Go standard library hash/crc32

### DIFF
--- a/crc32.go
+++ b/crc32.go
@@ -59,11 +59,12 @@ var IEEETable = makeTable(IEEE)
 // slicing8Table is array of 8 Tables
 type slicing8Table [8]Table
 
-// iEEETable8 is the slicing8Table for IEEE
-var iEEETable8 *slicing8Table
-var iEEETable8Once sync.Once
+// ieeeTable8 is the slicing8Table for IEEE
+var ieeeTable8 *slicing8Table
+var ieeeTable8Once sync.Once
 
-// MakeTable returns the Table constructed from the specified polynomial.
+// MakeTable returns a Table constructed from the specified polynomial.
+// The contents of this Table must not be modified.
 func MakeTable(poly uint32) *Table {
 	switch poly {
 	case IEEE:
@@ -114,10 +115,12 @@ type digest struct {
 
 // New creates a new hash.Hash32 computing the CRC-32 checksum
 // using the polynomial represented by the Table.
+// Its Sum method will lay the value out in big-endian byte order.
 func New(tab *Table) hash.Hash32 { return &digest{0, tab} }
 
 // NewIEEE creates a new hash.Hash32 computing the CRC-32 checksum
 // using the IEEE polynomial.
+// Its Sum method will lay the value out in big-endian byte order.
 func NewIEEE() hash.Hash32 { return New(IEEETable) }
 
 func (d *digest) Size() int { return Size }
@@ -155,7 +158,8 @@ func updateSlicingBy8(crc uint32, tab *slicing8Table, p []byte) uint32 {
 func Update(crc uint32, tab *Table, p []byte) uint32 {
 	if tab == castagnoliTable {
 		return updateCastagnoli(crc, p)
-	} else if tab == IEEETable {
+	}
+	if tab == IEEETable {
 		return updateIEEE(crc, p)
 	}
 	return update(crc, tab, p)

--- a/crc32_amd64.go
+++ b/crc32_amd64.go
@@ -9,7 +9,7 @@ package crc32
 // This file contains the code to call the SSE 4.2 version of the Castagnoli
 // and IEEE CRC.
 
-// haveSSE41/haveSSE42/haveCLMUL are defined in crc_amd64.s and uses
+// haveSSE41/haveSSE42/haveCLMUL are defined in crc_amd64.s and use
 // CPUID to test for SSE 4.1, 4.2 and CLMUL support.
 func haveSSE41() bool
 func haveSSE42() bool
@@ -17,12 +17,12 @@ func haveCLMUL() bool
 
 // castagnoliSSE42 is defined in crc_amd64.s and uses the SSE4.2 CRC32
 // instruction.
-// go:noescape
+//go:noescape
 func castagnoliSSE42(crc uint32, p []byte) uint32
 
 // ieeeCLMUL is defined in crc_amd64.s and uses the PCLMULQDQ
 // instruction as well as SSE 4.1.
-// go:noescape
+//go:noescape
 func ieeeCLMUL(crc uint32, p []byte) uint32
 
 var sse42 = haveSSE42()
@@ -43,7 +43,7 @@ func updateIEEE(crc uint32, p []byte) uint32 {
 	if useFastIEEE && len(p) >= 64 {
 		left := len(p) & 15
 		do := len(p) - left
-		crc := ^ieeeCLMUL(^crc, p[:do])
+		crc = ^ieeeCLMUL(^crc, p[:do])
 		if left > 0 {
 			crc = update(crc, IEEETable, p[do:])
 		}
@@ -52,10 +52,10 @@ func updateIEEE(crc uint32, p []byte) uint32 {
 
 	// only use slicing-by-8 when input is >= 16 Bytes
 	if len(p) >= 16 {
-		iEEETable8Once.Do(func() {
-			iEEETable8 = makeTable8(IEEE)
+		ieeeTable8Once.Do(func() {
+			ieeeTable8 = makeTable8(IEEE)
 		})
-		return updateSlicingBy8(crc, iEEETable8, p)
+		return updateSlicingBy8(crc, ieeeTable8, p)
 	}
 
 	return update(crc, IEEETable, p)

--- a/crc32_amd64p32.go
+++ b/crc32_amd64p32.go
@@ -9,12 +9,13 @@ package crc32
 // This file contains the code to call the SSE 4.2 version of the Castagnoli
 // CRC.
 
-// haveSSE42 is defined in crc_amd64p32.s and uses CPUID to test for 4.2
+// haveSSE42 is defined in crc_amd64p32.s and uses CPUID to test for SSE 4.2
 // support.
 func haveSSE42() bool
 
 // castagnoliSSE42 is defined in crc_amd64.s and uses the SSE4.2 CRC32
 // instruction.
+//go:noescape
 func castagnoliSSE42(crc uint32, p []byte) uint32
 
 var sse42 = haveSSE42()
@@ -29,10 +30,10 @@ func updateCastagnoli(crc uint32, p []byte) uint32 {
 func updateIEEE(crc uint32, p []byte) uint32 {
 	// only use slicing-by-8 when input is >= 4KB
 	if len(p) >= 4096 {
-		iEEETable8Once.Do(func() {
-			iEEETable8 = makeTable8(IEEE)
+		ieeeTable8Once.Do(func() {
+			ieeeTable8 = makeTable8(IEEE)
 		})
-		return updateSlicingBy8(crc, iEEETable8, p)
+		return updateSlicingBy8(crc, ieeeTable8, p)
 	}
 
 	return update(crc, IEEETable, p)

--- a/crc32_generic.go
+++ b/crc32_generic.go
@@ -6,8 +6,9 @@
 
 package crc32
 
-// The file contains the generic version of updateCastagnoli which does
+// This file contains the generic version of updateCastagnoli which does
 // slicing-by-8, or uses the fallback for very small sizes.
+
 func updateCastagnoli(crc uint32, p []byte) uint32 {
 	// only use slicing-by-8 when input is >= 16 Bytes
 	if len(p) >= 16 {
@@ -19,10 +20,10 @@ func updateCastagnoli(crc uint32, p []byte) uint32 {
 func updateIEEE(crc uint32, p []byte) uint32 {
 	// only use slicing-by-8 when input is >= 16 Bytes
 	if len(p) >= 16 {
-		iEEETable8Once.Do(func() {
-			iEEETable8 = makeTable8(IEEE)
+		ieeeTable8Once.Do(func() {
+			ieeeTable8 = makeTable8(IEEE)
 		})
-		return updateSlicingBy8(crc, iEEETable8, p)
+		return updateSlicingBy8(crc, ieeeTable8, p)
 	}
 	return update(crc, IEEETable, p)
 }


### PR DESCRIPTION
I diffed klauspost/crc32 against standard hash/crc32 and made some changes to align them a bit more closely. I expect that many of these are simply changes that have been made in hash/crc32 since you forked it. This is just to reduce the diffs when you send this code in for Go 1.7.

I didn't look closely at the assembly files because of all the spacing diffs. If there are important changes there (the only one I found was possibly MOVOA turning into MOVOU), please make them anew in the eventual Go 1.7 CL so as to avoid including all the formatting changes. In general I'm in favor of having some kind of asmfmt, but we don't yet, and it's much easier to review if the CL only contains semantic changes.

Thanks very much.